### PR TITLE
Add 'ts-postgres' to Node.js driver tests

### DIFF
--- a/_nodejs/package.json
+++ b/_nodejs/package.json
@@ -9,6 +9,7 @@
         "csv-write-stream": "2.0.0",
         "pg": "~7.4.3",
         "pg-copy-streams": "1.2.0",
-        "pg-native": "~3.0.0"
+        "pg-native": "~3.0.0",
+        "ts-postgres": "~1.0.0-rc2"
     }
 }

--- a/pgbench
+++ b/pgbench
@@ -361,6 +361,8 @@ BENCHMARKS = [
     'python-aiopg-tuples',
     'python-asyncpg',
     'nodejs-pg-js',
+    'nodejs-pg-native',
+    'nodejs-ts-postgres'
 ]
 
 


### PR DESCRIPTION
This adds [ts-postgres](https://www.npmjs.com/package/ts-postgres) to the Node.js benchmarks.

![image](https://user-images.githubusercontent.com/26405/47253521-484ac080-d454-11e8-9402-5408ea77b4af.png)
