### PR TITLE
Fixing issues regarding psycopg2 vs psycopg3 benchmark

### DIFF
--- a/_python/pgbench_python.py
+++ b/_python/pgbench_python.py
@@ -88,11 +88,13 @@ def psycopg_copy(conn, query, args):
 def psycopg2_executemany(conn, query, args):
     cur = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
     cur.executemany(query, args)
+    conn.commit()
     return len(args)
 
 def psycopg_executemany(conn, query, args):
     with conn.cursor() as cur:
         cur.executemany(query, args)
+        conn.commit()
     return len(args)
 
 
@@ -183,6 +185,7 @@ async def asyncpg_executemany(conn, query, args):
 async def async_psycopg_executemany(conn, query, args):
     async with conn.cursor() as cur:
         await cur.executemany(query, args)
+        await conn.commit()
     return len(args)
 
 
@@ -247,7 +250,8 @@ def sync_worker(executor, eargs, start, duration, timeout):
             max_latency = req_time
         if req_time < min_latency:
             min_latency = req_time
-        latency_stats[req_time] += 1
+        if req_time <= 200000:
+            latency_stats[req_time] += 1
         queries += 1
 
     return queries, rows, latency_stats, min_latency, max_latency

--- a/_python/requirements.txt
+++ b/_python/requirements.txt
@@ -1,7 +1,7 @@
 aiopg==1.4.0
 asyncpg==0.27.0
 py-postgresql==1.3.0
-psycopg2-binary==2.9.6
+psycopg2-binary==2.9.9
 numpy>=1.25.0
 uvloop~=0.17.0
-psycopg[binary]==3.1.9
+psycopg[binary]==3.1.18

--- a/pgbench
+++ b/pgbench
@@ -356,6 +356,8 @@ BENCHMARKS = [
     'golang-libpq',
     'golang-pgx',
     'python-aiopg',
+    'python-psycopg2',
+    'python-psycopg3',
     'python-aiopg-tuples',
     'python-asyncpg',
     'python-psycopg3-async',


### PR DESCRIPTION
- Updating dependencies versions
- A hack to overcome out of index error while running psycopg3 batch inserts benchmark
- Adding conn.commit() so that we can commit data into PostgreSQL
- Adding python-psycopg2 and python-psycopg3 keywords so that they can be run from pgbench utility as well